### PR TITLE
Replacing outdated `text-davinci` models with `gpt-3.5-turbo-instruct`

### DIFF
--- a/datasloth/__init__.py
+++ b/datasloth/__init__.py
@@ -123,7 +123,7 @@ SQL query for SQLite:
             return
         prompt += DataSloth.prompt_format.format(QUERY=query)
         response = openai.Completion.create(
-            model="gpt-3.5-turbo-instruct"", # as per OpenAI deprecations guide: https://platform.openai.com/docs/deprecations/instructgpt-models
+            model="gpt-3.5-turbo-instruct", # as per OpenAI deprecations guide: https://platform.openai.com/docs/deprecations/instructgpt-models
             prompt=prompt,
             temperature=0,
             max_tokens=1000,

--- a/datasloth/__init__.py
+++ b/datasloth/__init__.py
@@ -123,7 +123,7 @@ SQL query for SQLite:
             return
         prompt += DataSloth.prompt_format.format(QUERY=query)
         response = openai.Completion.create(
-            model="text-davinci-002",
+            model="gpt-3.5-turbo-instruct"", # as per OpenAI deprecations guide: https://platform.openai.com/docs/deprecations/instructgpt-models
             prompt=prompt,
             temperature=0,
             max_tokens=1000,
@@ -155,7 +155,7 @@ SQL query for SQLite:
             prompt += f"|{'|'.join(columns)}|\n"
             prompt += f"|{'|'.join(['-'*len(col) for col in columns])}|\n|"
             response = openai.Completion.create(
-                model="text-davinci-002",
+                model="gpt-3.5-turbo-instruct", # as per OpenAI deprecations guide: https://platform.openai.com/docs/deprecations/instructgpt-models
                 prompt=prompt,
                 temperature=0.8,
                 max_tokens=1000,


### PR DESCRIPTION
# Problem

Current version of the library does not work as-is querying the `davinci` models, throwing:
```py
openai.error.InvalidRequestError: The model `text-davinci-002` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations
```

# Solution
This PR replaces the default model called with `gpt-3.5-turbo-instruct` as suggested by [OpenAI deprecations guide](https://platform.openai.com/docs/deprecations/instructgpt-models) works.

## Extra notes
The project also uses an outdated `openai` library version, so version `0.28` should be used:
```pip install openai==0.28```
